### PR TITLE
Add install code, fix & improve CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,17 +4,37 @@ on: [push]
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
-    runs-on: ubuntu-latest
-    
     steps:
     - name: CheckOut
       uses: actions/checkout@v1
-    - name: install_dependencies
-      run: sudo apt-get install cmake ninja-build libsdl2-dev
-    - name: configure
-      run: mkdir build && cd build && cmake ..
-    - name: make build
-      run: cd build && cmake --build . --config Release --target pmdplay
-    - name: make check
-      run: cd build && ./pmdplay ../PC-98_Hartmann_s_Youkai_GIrl.M PC-98_Hartmann_s_Youkai_GIrl.wav
+
+    - name: Install Dependencies [Linux]
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install cmake libsdl2-dev
+    - name: Install Dependencies [Darwin]
+      if: matrix.os == 'macos-latest'
+      run: |
+        export HOMEBREW_NO_INSTALL_CLEANUP=1
+        brew update
+        # cmake is preinstalled, trying to install it again will error out
+        brew install sdl2
+
+    - name: Configure
+      run: |
+        mkdir build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+    - name: Build
+      run: |
+        make -C build -j2
+    - name: Check
+      run: |
+        cd build
+        echo "Checking if pmdplay works: ./pmdplay ../PC-98_Hartmann_s_Youkai_GIrl.M PC-98_Hartmann_s_Youkai_GIrl.wav"
+        ./pmdplay ../PC-98_Hartmann_s_Youkai_GIrl.M PC-98_Hartmann_s_Youkai_GIrl.wav

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ file(GLOB SOURCES sdlplay.cpp)
 
 include_directories(src src/fmgen src/pmdwin)
 
-add_executable(pmdplay EXCLUDE_FROM_ALL ${SOURCES})
+add_executable(pmdplay ${SOURCES})
 
 if(MSVC)
 	target_link_libraries(pmdplay PRIVATE pmdmini SDL2::SDL2 SDL2::SDL2main)
@@ -41,3 +41,6 @@ if(UNIX OR MINGW)
 	target_include_directories(pmdplay PUBLIC ${SDL2_INCLUDE_DIRS})
 	target_compile_options(pmdplay PUBLIC ${SDL2_FLAGS} ${SDL2_FLAGS_OTHERS})
 endif()
+
+include(GNUInstallDirs)
+install(TARGETS pmdplay DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(MSVC)
 endif()
 
 if(UNIX OR MINGW)
-	target_link_libraries(pmdplay PRIVATE pmdmini ${SDL2_LIBRARIES} m)
+	target_link_libraries(pmdplay PRIVATE pmdmini ${SDL2_LINK_LIBRARIES} m)
 	target_include_directories(pmdplay PUBLIC ${SDL2_INCLUDE_DIRS})
 	target_compile_options(pmdplay PUBLIC ${SDL2_FLAGS} ${SDL2_FLAGS_OTHERS})
 endif()


### PR DESCRIPTION
Closes #5.

- Unhid the pmdplay target from a normal build (was there a reason that was done?)
- Added install code for pmdplay target
- Fixed an SDL2 linking problem I got on Darwin CI
- Fixed current Ubuntu CI & added Darwin CI