### PR TITLE
Use SDL2_LDFLAGS for linking instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(MSVC)
 endif()
 
 if(UNIX OR MINGW)
-	target_link_libraries(pmdplay PRIVATE pmdmini ${SDL2_LINK_LIBRARIES} m)
+	target_link_libraries(pmdplay PRIVATE pmdmini ${SDL2_LDFLAGS} m)
 	target_include_directories(pmdplay PUBLIC ${SDL2_INCLUDE_DIRS})
 	target_compile_options(pmdplay PUBLIC ${SDL2_FLAGS} ${SDL2_FLAGS_OTHERS})
 endif()


### PR DESCRIPTION
I failed to check when `XXX_LINK_LIBRARIES` was introduced: CMake file declares the minimum required CMake version as 3.0 (Unix) / 3.10 (Windows) but that's a 3.12 variable & fails on my Ubuntu 18.04 system. Using `XXX_LDFLAGS` works better.